### PR TITLE
Fix code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/server/mapping.go
+++ b/server/mapping.go
@@ -83,7 +83,7 @@ func Handles(dm *Database) (*common.Reference, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error parsing target <%s>: %s -> %s", dm.Target, err, target)
 	}
-	log.Log.Debugf("Register database handler %#v", dm)
+	log.Log.Debugf("Register database handler for target %s", dm.Target)
 	_, err = flynn.Handler(ref, os.ExpandEnv(dm.Password))
 	if err != nil {
 		services.ServerMessage("Error registering database <%s>: %v", dm.Target, err)


### PR DESCRIPTION
Fixes [https://github.com/tknie/clu/security/code-scanning/7](https://github.com/tknie/clu/security/code-scanning/7)

To fix the problem, we need to ensure that sensitive information, such as passwords, is not logged in clear text. The best way to achieve this is to modify the logging statements to exclude sensitive data. Specifically, we should avoid logging the entire `dm` object and instead log only the necessary non-sensitive information.

1. In `server/mapping.go`, update the logging statement on line 86 to exclude the `dm` object.
2. Ensure that any other logging statements that might include sensitive information are also updated accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
