### PR TITLE
Fix code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/server/mapping.go
+++ b/server/mapping.go
@@ -122,7 +122,7 @@ func checkFilter(filters []string, table string) bool {
 func loadTableOfDatabases() {
 	log.Log.Debugf("Refreshing database list")
 	for _, dm := range Viewer.Database.DatabaseAccess.Database {
-		log.Log.Debugf("Access database %#v", dm)
+		log.Log.Debugf("Access database %s with user %s", dm.Target, dm.User)
 		//u := dm.URL
 		//m := regexp.MustCompile(`(?m):[^:]*@`)
 		//m := regexp.MustCompile(`(?m)\${[^{]*PASS[^}]*}`)


### PR DESCRIPTION
Fixes [https://github.com/tknie/clu/security/code-scanning/8](https://github.com/tknie/clu/security/code-scanning/8)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged in clear text. The best way to fix this is to obfuscate or omit the sensitive information before logging. Specifically, we should modify the logging statement on line 125 in `server/mapping.go` to exclude the password.

1. Identify the logging statement that logs the `dm` object.
2. Modify the logging statement to exclude sensitive information.
3. Ensure that the `Password` field is not logged by replacing it with a placeholder or omitting it entirely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
