### PR TITLE
Fix code scanning alert no. 6: Clear-text logging of sensitive information

### DIFF
--- a/server/mapping.go
+++ b/server/mapping.go
@@ -72,18 +72,18 @@ func Handles(dm *Database) (*common.Reference, error) {
 	dHash := databaseHash(dm)
 	if e, ok := dbDictionary.Load(dHash); ok {
 		regEntry := e.(*databaseRegister)
-		log.Log.Debugf("Found database hash %s -> %s", dHash, os.ExpandEnv(dm.String()))
+		log.Log.Debugf("Found database hash %s", dHash)
 		atomic.AddUint64(&regEntry.readCount, 1)
 		return regEntry.reference, nil
 	}
-	log.Log.Infof("Add database hash %s -> %s", dHash, os.ExpandEnv(dm.String()))
+	log.Log.Infof("Add database hash %s", dHash)
 	target := os.ExpandEnv(dm.Target)
 	log.Log.Debugf("Handles %s", target)
 	ref, _, err := common.NewReference(target)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing target <%s>: %s -> %s", dm.Target, err, target)
 	}
-	log.Log.Debugf("Register database handler %#v", dm)
+	log.Log.Debugf("Register database handler for target %s", dm.Target)
 	_, err = flynn.Handler(ref, os.ExpandEnv(dm.Password))
 	if err != nil {
 		services.ServerMessage("Error registering database <%s>: %v", dm.Target, err)


### PR DESCRIPTION
Fixes [https://github.com/tknie/clu/security/code-scanning/6](https://github.com/tknie/clu/security/code-scanning/6)

To fix the problem, we need to ensure that sensitive information, such as passwords, is not logged in clear text. This can be achieved by obfuscating or omitting the sensitive information in the log statements. Specifically, we should:

1. Modify the logging statements in `server/mapping.go` to exclude sensitive information.
2. Ensure that any sensitive data is handled securely and not exposed in logs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
