### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,10 @@
 
 name: Go
 
+permissions:
+  contents: read
+  actions: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/tknie/clu/security/code-scanning/14](https://github.com/tknie/clu/security/code-scanning/14)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Based on the workflow's steps, it primarily needs to read repository contents and upload artifacts. Therefore, we will set `contents: read` and `actions: read` permissions. If additional permissions are required for specific steps, they can be added later.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
